### PR TITLE
Feature/inline executor

### DIFF
--- a/sdk/halo-sdk/src/main/java/com/mobgen/halo/android/sdk/core/threading/HaloInteractorExecutor.java
+++ b/sdk/halo-sdk/src/main/java/com/mobgen/halo/android/sdk/core/threading/HaloInteractorExecutor.java
@@ -155,10 +155,9 @@ public final class HaloInteractorExecutor<T> implements ICancellable, ThreadCont
     }
 
     /**
-     * Executes a inline given operation into the thread manager in the same thread
+     * Executes given operation into the thread manager in the same thread given an inline response.
      *
-     * @return A cancellable interface. In this case it is the same
-     * executor but casted.
+     * @return The result of the operation wrapped on HaloResultV2 object.
      */
     @Nullable
     @Api(2.33)

--- a/sdk/halo-sdk/src/main/java/com/mobgen/halo/android/sdk/core/threading/HaloInteractorExecutor.java
+++ b/sdk/halo-sdk/src/main/java/com/mobgen/halo/android/sdk/core/threading/HaloInteractorExecutor.java
@@ -155,7 +155,7 @@ public final class HaloInteractorExecutor<T> implements ICancellable, ThreadCont
     }
 
     /**
-     * Executes given operation into the thread manager in the same thread given an inline response.
+     * Executes the given operation into the thread manager in the same thread providing an inline response.
      *
      * @return The result of the operation wrapped on HaloResultV2 object.
      */
@@ -163,7 +163,7 @@ public final class HaloInteractorExecutor<T> implements ICancellable, ThreadCont
     @Api(2.33)
     @CheckResult(suggest = "This execution will be always with a SAME_THREAD_POLICY.")
     public final HaloResultV2<T> executeInline() {
-        this.threadPolicy(Threading.SAME_THREAD_POLICY);
+        threadPolicy(Threading.SAME_THREAD_POLICY);
         HaloResultV2<T> resultingData = null;
         if (mExecutionCallback != null) {
             mExecutionCallback.onPreExecute();

--- a/sdk/halo-sdk/src/main/java/com/mobgen/halo/android/sdk/core/threading/HaloInteractorExecutor.java
+++ b/sdk/halo-sdk/src/main/java/com/mobgen/halo/android/sdk/core/threading/HaloInteractorExecutor.java
@@ -154,6 +154,35 @@ public final class HaloInteractorExecutor<T> implements ICancellable, ThreadCont
     }
 
     /**
+     * Executes a inline given operation into the thread manager in the same thread
+     *
+     * @return A cancellable interface. In this case it is the same
+     * executor but casted.
+     */
+    @Nullable
+    @Api(2.33)
+    public final HaloResultV2<T> executeInline() {
+        this.threadPolicy(Threading.SAME_THREAD_POLICY);
+        HaloResultV2<T> resultingData = null;
+        if (mExecutionCallback != null) {
+            mExecutionCallback.onPreExecute();
+        }
+        try {
+            resultingData = mInteractor.executeInteractor();
+        } catch (Exception e) {
+            //Notify erroneous execution
+            HaloStatus status = HaloStatus.builder()
+                    .error(e)
+                    .build();
+            resultingData = new HaloResultV2<T>(status, null);
+        }
+        if (mExecutionCallback != null) {
+            mExecutionCallback.onPostExecute();
+        }
+        return resultingData;
+    }
+
+    /**
      * Checks if the selector is cancelled.
      *
      * @return True if cancelled, false otherwise.

--- a/sdk/halo-sdk/src/main/java/com/mobgen/halo/android/sdk/core/threading/HaloInteractorExecutor.java
+++ b/sdk/halo-sdk/src/main/java/com/mobgen/halo/android/sdk/core/threading/HaloInteractorExecutor.java
@@ -2,6 +2,7 @@ package com.mobgen.halo.android.sdk.core.threading;
 
 import android.os.Handler;
 import android.os.Looper;
+import android.support.annotation.CheckResult;
 import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -102,7 +103,7 @@ public final class HaloInteractorExecutor<T> implements ICancellable, ThreadCont
         mInteractor = interactor;
         mExecutionCallback = executionCallback;
         mThreadPolicy = Threading.POOL_QUEUE_POLICY;
-        if(Looper.myLooper() != null){
+        if (Looper.myLooper() != null) {
             mResultHandler = new Handler(Looper.myLooper());
         }
     }
@@ -161,6 +162,7 @@ public final class HaloInteractorExecutor<T> implements ICancellable, ThreadCont
      */
     @Nullable
     @Api(2.33)
+    @CheckResult(suggest = "This execution will be always with a SAME_THREAD_POLICY.")
     public final HaloResultV2<T> executeInline() {
         this.threadPolicy(Threading.SAME_THREAD_POLICY);
         HaloResultV2<T> resultingData = null;

--- a/sdk/halo-sdk/src/test/java/com/mobgen/halo/android/sdk/core/management/HaloManagerApiTest.java
+++ b/sdk/halo-sdk/src/test/java/com/mobgen/halo/android/sdk/core/management/HaloManagerApiTest.java
@@ -10,6 +10,7 @@ import com.mobgen.halo.android.framework.toolbox.bus.Event;
 import com.mobgen.halo.android.framework.toolbox.bus.Subscriber;
 import com.mobgen.halo.android.framework.toolbox.data.CallbackV2;
 import com.mobgen.halo.android.framework.toolbox.data.Data;
+import com.mobgen.halo.android.framework.toolbox.data.HaloResultV2;
 import com.mobgen.halo.android.framework.toolbox.threading.Threading;
 import com.mobgen.halo.android.sdk.api.Halo;
 import com.mobgen.halo.android.sdk.core.management.device.DeviceLocalDatasource;
@@ -42,6 +43,7 @@ import static com.mobgen.halo.android.sdk.mock.fixtures.ServerFixtures.REMOVE_SE
 import static com.mobgen.halo.android.sdk.mock.fixtures.ServerFixtures.REQUEST_TOKEN;
 import static com.mobgen.halo.android.sdk.mock.fixtures.ServerFixtures.SYNC_DEVICE;
 import static com.mobgen.halo.android.sdk.mock.fixtures.ServerFixtures.TEST_SERVER_VERSION;
+import static com.mobgen.halo.android.sdk.mock.fixtures.ServerFixtures.enqueueServerError;
 import static com.mobgen.halo.android.sdk.mock.fixtures.ServerFixtures.enqueueServerFile;
 import static com.mobgen.halo.android.sdk.mock.instrumentation.HaloManagerApiInstrument.givenCallbackServerVersion;
 import static com.mobgen.halo.android.sdk.mock.instrumentation.HaloManagerApiInstrument.givenCallbackWithDeviceSegmentationTagAdd;
@@ -386,5 +388,25 @@ public class HaloManagerApiTest extends HaloRobolectricTest {
                 .execute(callback);
         assertThat(mCallbackFlag.isFlagged()).isTrue();
         assertThat(cancellable).isNotNull();
+    }
+
+    @Test
+    public void thatCanSetNotificationTokenInlineResponse() throws IOException {
+        enqueueServerFile(mMockServer, GET_DEVICE);
+        HaloResultV2<Device> result = mHalo.manager()
+                .setNotificationsToken("mytoken")
+                .executeInline();
+        assertThat(result.data()).isNotNull();
+        assertThat(result.data().getNotificationsToken()).isEqualTo("mytoken");
+    }
+
+    @Test
+    public void thatCanHandleExceptionWithAnInlineResponse() throws IOException {
+        enqueueServerError(mMockServer,500);
+        HaloResultV2<Device> result = mHalo.manager()
+                .setNotificationsToken("mytoken")
+                .executeInline();
+        assertThat(result.data()).isNull();
+        assertThat(result.status().isError()).isTrue();
     }
 }


### PR DESCRIPTION
Allow to execute "sync" requests (same execution thread) that returns responses (inline, no callback needed)